### PR TITLE
Use doParallel package to try to parallelize model training

### DIFF
--- a/scripts/4.2_create_training_scripts.R
+++ b/scripts/4.2_create_training_scripts.R
@@ -32,7 +32,8 @@ tuning_grid = train_master_df %>%
   map_df(1)
 
 # Set up parallelization
-cluster = makePSOCKcluster(4)
+number_of_cores = 4
+cluster = makePSOCKcluster(number_of_cores)
 registerDoParallel(cluster)
 
 # train the model 


### PR DESCRIPTION
Try to use the doParallel package, following the guidance in the [caret documentation](http://topepo.github.io/caret/parallel-processing.html), to parallelize the model training. The only real question is what the value on line 35, for the number of CPU cores to use, should be? Currently it is hard-coded to 4, but the "right" value depends on the hardware used.