### PR TITLE
Use seq_along instead of explicitly creating loop index range

### DIFF
--- a/scripts/4.2_create_training_scripts.R
+++ b/scripts/4.2_create_training_scripts.R
@@ -18,7 +18,7 @@ model = train(diagnosis ~ .,
               tuneGrid = tuning_grid,
               metric = 'Kappa'"
   
-  for (i in 1:length(add_args)) { 
+  for (i in seq_along(add_args)) { 
     arg_name = names(add_args[i])
     a = add_args[i]
     default_text = glue(default_text, ", \n {arg_name} = {a}")


### PR DESCRIPTION
Use `seq_along`, instead of explicitly creating the range for the loop index, because it can avoid issues when `add_args` is empty.