### PR TITLE
remove line that checks if 'models' are of class 'vector'.

### DIFF
--- a/scripts/0.2_residualize.R
+++ b/scripts/0.2_residualize.R
@@ -88,7 +88,6 @@ residualize = function(VOI = NULL, VTC = NULL, id = NULL, data = NULL){
     predicted.values <- data.frame(matrix(unlist(predicted.values), ncol=length(predicted.values), byrow=F))
     colnames(predicted.values) = names(models)
   }
-  if(is.vector(models)) predicted.values = estimate.pred(pred.mat, coef = models, id = id)
   
   # calculate mean of each VOI
   means = sapply(VOI, FUN = function(x) mean(data[,x], na.rm=T))


### PR DESCRIPTION
Hey Sara--

After you built in some of the if statements the other day to the `residualize()` function to account for different possible combinations of "variables to control", the function started to have trouble if any VTC's are factors. For some reason, if `models` is a list (which I think happens when at least one VTC is a factor), both `is.list(models)` _and_ `is.vector(models)` evaluate to `TRUE`. So, the line I removed (line 91) is evaluated and it runs into an error with the `estimate.pred()` function. 

Removing this line entirely makes the function work. I think `models` will actually only ever be either a list or a matrix,  even if `VTC` is of length 1. I feel like I'm not explaining the issue super well, so I'm happy to talk more about this in person!